### PR TITLE
Removed boost as dependency and use std::regex (c++11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ same machine.
 The client only works with MPD versions >= 0.15.0.
 
 You'll need `glib >= 2.0`, `ncurses >= 5.0`, and `libmpdclient >= 2.5` to build
-PMS. Installing `boost_regex >= 1.36.0` will enable regular expression searches.
+PMS. If your c++ compiler supports c++11's regex (like `gcc-c++ >= 4.9`),
+it will enable regular expression searches.
 In addition, if building from Git, you'll need the `intltool` package. On
 Debian-based systems, you can install them by running:
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([src/pms.cpp])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
-
+AC_LANG(C++)
 # Enable debugging?
 AX_CHECK_ENABLE_DEBUG
 
@@ -47,9 +47,10 @@ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE],
 
 # Other stuff
 AC_ARG_ENABLE([regex],
-       [AS_HELP_STRING([--enable-regex], [Support pattern matching through the boost regex library (default: disable)])],
+              [AS_HELP_STRING([--enable-regex], [Support pattern matching through c++11 regex (needs gcc >= 4.9 or other compatible compiler) (default: disable)])],
        [case "${enableval}" in
-               yes) AC_CHECK_LIB([boost_regex], [main]) ;;
+            yes) AX_CXX_COMPILE_STDCXX_11([noext], [mandatory])
+            AC_DEFINE([HAVE_REGEX], [1], [C++ 11 is available and regex is part of it]);;
        esac])
 
 AC_CONFIG_FILES([Makefile

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -1,0 +1,172 @@
+# ============================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_11.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX_11([ext|noext],[mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the C++11
+#   standard; if necessary, add switches to CXXFLAGS to enable support.
+#
+#   The first argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The second argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline C++11 support is required and that the macro
+#   should error out if no mode with that support is found.  If specified
+#   'optional', then configuration proceeds regardless, after defining
+#   HAVE_CXX11 if and only if a supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 13
+
+m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    struct Base {
+    virtual void f() {}
+    };
+    struct Child : public Base {
+    virtual void f() override {}
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);
+
+    auto d = a;
+    auto l = [](){};
+    // Prevent Clang error: unused variable 'l' [-Werror,-Wunused-variable]
+    struct use_l { use_l() { l(); } };
+
+    // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+    // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function because of this
+    namespace test_template_alias_sfinae {
+        struct foo {};
+
+        template<typename T>
+        using member = typename T::member_type;
+
+        template<typename T>
+        void func(...) {}
+
+        template<typename T>
+        void func(member<T>*) {}
+
+        void test();
+
+        void test() {
+            func<foo>(0);
+        }
+    }
+
+    // Check for C++11 attribute support
+    void noret [[noreturn]] () { throw 0; }
+]])
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
+  m4_if([$1], [], [],
+        [$1], [ext], [],
+        [$1], [noext], [],
+        [m4_fatal([invalid argument `$1' to AX_CXX_COMPILE_STDCXX_11])])dnl
+  m4_if([$2], [], [ax_cxx_compile_cxx11_required=true],
+        [$2], [mandatory], [ax_cxx_compile_cxx11_required=true],
+        [$2], [optional], [ax_cxx_compile_cxx11_required=false],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX_11])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+  AC_CACHE_CHECK(whether $CXX supports C++11 features by default,
+  ax_cv_cxx_compile_cxx11,
+  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
+    [ax_cv_cxx_compile_cxx11=yes],
+    [ax_cv_cxx_compile_cxx11=no])])
+  if test x$ax_cv_cxx_compile_cxx11 = xyes; then
+    ac_success=yes
+  fi
+
+  m4_if([$1], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for switch in -std=gnu++11 -std=gnu++0x; do
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx11_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
+                     $cachevar,
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
+      if eval test x\$$cachevar = xyes; then
+        CXXFLAGS="$CXXFLAGS $switch"
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$1], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    for switch in -std=c++11 -std=c++0x +std=c++11 "-h std=c++11"; do
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx11_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
+                     $cachevar,
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
+      if eval test x\$$cachevar = xyes; then
+        CXXFLAGS="$CXXFLAGS $switch"
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx11_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++11 language features is required.])
+    fi
+  else
+    if test x$ac_success = xno; then
+      HAVE_CXX11=0
+      AC_MSG_NOTICE([No compiler with C++11 support was found])
+    else
+      HAVE_CXX11=1
+      AC_DEFINE(HAVE_CXX11,1,
+                [define if the compiler supports basic C++11 syntax])
+    fi
+
+    AC_SUBST(HAVE_CXX11)
+  fi
+])

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -167,9 +167,8 @@ Mpd_status::alive() const
 {
 	/* FIXME: what is this? */
 	assert(0);
+	return false;
 }
-
-
 
 /*
  * Command class manages commands sent to and from mpd
@@ -1099,7 +1098,7 @@ Control::move(Songlist * list, int offset)
 		return 0;
 
 	filename = list->filename.c_str();
-	
+
 	if (offset < 0) {
 		song = list->getnextselected();
 	} else {
@@ -1874,7 +1873,7 @@ Control::is_idle()
 	return _is_idle;
 }
 
-bool
+void
 Control::set_is_idle(bool i)
 {
 	_is_idle = i;

--- a/src/command.h
+++ b/src/command.h
@@ -190,7 +190,7 @@ private:
 public:
 					Directory(Directory *, string);
 					~Directory();
-	
+
 	int				cursor;
 	vector<Song *>			songs;
 	vector<Directory *>		children;
@@ -301,7 +301,7 @@ public:
 	bool			noidle();
 	bool			wait_until_noidle();
 	bool			is_idle();
-	bool			set_is_idle(bool);
+	void			set_is_idle(bool);
 
 	/* List management */
 	Playlist *		find_playlist(string filename);
@@ -329,5 +329,5 @@ public:
 	bool		song_changed();
 	Songlist *	plist(int);
 };
- 
+
 #endif /* _PMS_COMMAND_H_ */

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -22,8 +22,8 @@
 
 
 #include "../config.h"
-#ifdef HAVE_LIBBOOST_REGEX
-	#include <boost/regex.hpp>
+#ifdef HAVE_REGEX
+	#include <regex>
 #endif
 #include "conn.h"
 #include "list.h"
@@ -233,7 +233,7 @@ song_t		Songlist::prevof(string s)
  * Finds next or previous entry of any type.
  */
 song_t		Songlist::findentry(Item field, bool reverse)
-{	
+{
 	Song *		song;
 	song_t		i = MATCH_FAILED;
 	long		mode = 0;
@@ -394,7 +394,7 @@ Songlist::filter_clear()
 		delete *it;
 		++it;
 	}
-	
+
 	filters.clear();
 	filtersongs = songs;
 }
@@ -436,7 +436,7 @@ bool		Songlist::filter_match(Song * s)
 
 	if (filters.size() == 0)
 		return true;
-	
+
 	it = filters.begin();
 	while (it != filters.end())
 	{
@@ -455,7 +455,7 @@ Filter *	Songlist::lastfilter()
 {
 	if (filters.size() == 0)
 		return NULL;
-	
+
 	return filters[filters.size() - 1];
 }
 
@@ -912,7 +912,7 @@ unsigned int		Songlist::cursor()
 unsigned int		Songlist::qlength()
 {
 	unsigned int		i, songpos;
-	
+
 	/* Find current playing song */
 	if (!pms->cursong() || pms->cursong()->id == MPD_SONG_NO_ID || pms->cursong()->pos == MPD_SONG_NO_NUM)
 	{
@@ -982,8 +982,8 @@ bool			Songlist::match(Song * song, string src, long mode)
 	bool				matched;
 	unsigned int			j;
 
-	/* try the sources in order of likeliness. ID etc last since if we're 
-	 * searching for them we likely won't be searching any of the other 
+	/* try the sources in order of likeliness. ID etc last since if we're
+	 * searching for them we likely won't be searching any of the other
 	 * fields. */
 	if (mode & MATCH_TITLE)			sources.push_back(song->title);
 	if (mode & MATCH_ARTIST)		sources.push_back(song->artist);
@@ -1007,7 +1007,7 @@ bool			Songlist::match(Song * song, string src, long mode)
 	{
 		if (mode & MATCH_EXACT)
 			matched = exactmatch(&(sources[j]), &src);
-#ifdef HAVE_LIBBOOST_REGEX
+#ifdef HAVE_REGEX
 		else if (pms->options->regexsearch)
 			matched = regexmatch(&(sources[j]), &src);
 #endif
@@ -1141,7 +1141,7 @@ bool		Songlist::perform_match(string * haystack, string * needle, int type)
 	}
 	if (type == 1 && it_needle == needle->end() && it_haystack != haystack->end())
 	{
-		/* need exact and got to the end of the needle but not the end of the 
+		/* need exact and got to the end of the needle but not the end of the
 		 * haystack */
 		return false;
 	}
@@ -1152,18 +1152,18 @@ bool		Songlist::perform_match(string * haystack, string * needle, int type)
 /*
  * Performs a case-insensitive regular expression match
  */
-#ifdef HAVE_LIBBOOST_REGEX
+#ifdef HAVE_REGEX
 bool		Songlist::regexmatch(string * source, string * pattern)
 {
-	bool			matched;
-	boost::regex		reg;
-
+	bool		matched;
+	regex		reg;
 	try
+
 	{
-		reg.assign(*pattern, boost::regex_constants::icase);
-		matched = boost::regex_search(source->begin(), source->end(), reg);
+		reg.assign(*pattern, std::regex_constants::icase);
+		matched = regex_search(*source, reg);
 	}
-	catch (boost::regex_error & err)
+	catch (std::regex_error& err)
 	{
 		return false;
 	}

--- a/src/list.h
+++ b/src/list.h
@@ -109,7 +109,7 @@ public:
 	bool			wrap;
 	List_role		role;
 	string			filename;
-	
+
 	Song *			song(song_t);
 	unsigned int		length;
 	void			clear();
@@ -122,7 +122,7 @@ public:
 	vector<song_t> *	matchall(string, long);
 	song_t			match(string, unsigned int, unsigned int, long);
 	bool			match(Song *, string, long);
-#ifdef HAVE_LIBBOOST_REGEX
+#ifdef HAVE_REGEX
 	bool			regexmatch(string *, string *);
 #endif
 	bool			exactmatch(string *, string *);

--- a/src/pms.cpp
+++ b/src/pms.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
 	}
 
 	delete pms;
-	return exitcode;	
+	return exitcode;
 }
 
 /**
@@ -330,6 +330,8 @@ Pms::run_all_events()
 	if (run_stdin_events()) {
 		return true;
 	}
+
+	return false;
 }
 
 /*
@@ -634,7 +636,7 @@ int			Pms::init()
 	char *			port;
 	char *			password;
 	const char *		charset = NULL;
-	
+
 	/* Internal pointers */
 	msg = new Message();
 	interface = new Interface();
@@ -799,7 +801,7 @@ vector<string> *	Pms::splitstr(string str, string delimiter)
 		last = str.find_first_not_of(delimiter, pos);
 		pos = str.find_first_of(delimiter, last);
 	}
-	
+
 	return tokens;
 }
 
@@ -822,7 +824,7 @@ string			Pms::joinstr(vector<string> * source, vector<string>::iterator start, v
 			dest += delimiter;
 		}
 	}
-	
+
 	return dest;
 }
 
@@ -972,8 +974,8 @@ bool			Pms::run_shell(string cmd)
 	}
 
 	/*
-	 * ##: path to each song in selection (or each song on the current 
-	 * playlist if there is no selection), each enclosed with doublequotes 
+	 * ##: path to each song in selection (or each song on the current
+	 * playlist if there is no selection), each enclosed with doublequotes
 	 * and separated by spaces
 	 */
 	list = disp->actwin()->plist();
@@ -1052,7 +1054,7 @@ Song *			Pms::cursong()
 	return comm->song();
 }
 
-/* 
+/*
  * Reset status to its natural state.
  */
 void
@@ -1334,7 +1336,7 @@ bool			Pms::progress_nextsong()
 	last_song_id = cursong()->id;
 
 	/* Normal progression: reached end of playlist */
-	if (cursong()->pos == static_cast<int>(playlist->list->end())) { 
+	if (cursong()->pos == static_cast<int>(playlist->list->end())) {
 
 		pms->log(MSG_DEBUG, 0, "Auto-progressing to next song.\n");
 


### PR DESCRIPTION
Replaced boost_regex with std::regex from c++11.

Also I fixed some non void functions with no return value.
This avoids return of random data and fixes warnings when building for Linux distributions using RPMLint.