### PR TITLE
Fix some build issues with GCC 5 and building with regex enabled.

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -59,42 +59,36 @@ BBox::BBox()
 	window = NULL;
 }
 
-inline
 uint16_t
 BBox::top()
 {
 	return tl.y;
 }
 
-inline
 uint16_t
 BBox::bottom()
 {
 	return br.y;
 }
 
-inline
 uint16_t
 BBox::left()
 {
 	return tl.x;
 }
 
-inline
 uint16_t
 BBox::right()
 {
 	return br.x;
 }
 
-inline
 uint16_t
 BBox::width()
 {
 	return br.x - tl.x + 1;
 }
 
-inline
 uint16_t
 BBox::height()
 {

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -174,14 +174,12 @@ List::item(uint32_t index)
 	return items[index];
 }
 
-inline
 uint32_t
 List::size()
 {
 	return items.size();
 }
 
-inline
 int32_t
 List::top_position()
 {
@@ -208,7 +206,6 @@ List::bottom_position()
 	return p;
 }
 
-inline
 int32_t
 List::min_top_position()
 {
@@ -451,7 +448,6 @@ List::build_selection_cache()
 	set_selection_cache_valid(true);
 }
 
-inline
 bool
 List::selection_cache_valid()
 {

--- a/src/song.cpp
+++ b/src/song.cpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 
+extern Pms * pms;
 
 Song::Song(const mpd_song * song)
 {


### PR DESCRIPTION
When building with regex enabled, build fails because no pms object
exists in song.cpp

GCC 5.x changed inlining behaviour, so linking fails with the inlined
functions in list.cpp and display.cpp