### PR TITLE
Disable building the manpage when pandoc is not present.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,7 @@
+if PANDOC
 SUBDIRS = src doc po .
+else
+SUBDIRS = src po .
+endif
 
 EXTRA_DIST = config.rpath

--- a/configure.ac
+++ b/configure.ac
@@ -27,8 +27,9 @@ PKG_CHECK_MODULES([libmpdclient], [libmpdclient >= 2.5],, [AC_MSG_ERROR([libmpdc
 # Check for Pandoc
 AC_PATH_PROG(PANDOC,pandoc,no)
 if [[ "x$PANDOC" = xno ]]; then
-    AC_MSG_ERROR([Pandoc is required to build the manual page])
+    AC_MSG_WARN([The manual page will not be built.])
 fi
+AM_CONDITIONAL([PANDOC], [test "x$PANDOC" = xyes])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h libintl.h limits.h locale.h netdb.h netinet/in.h stdlib.h string.h sys/param.h sys/socket.h sys/time.h unistd.h])


### PR DESCRIPTION
Pandoc is a big package and some people might not want to install it.