### PR TITLE
Fix some non void functions returning random data.

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1771,9 +1771,8 @@ int		createwindow(string param, List *& win, Songlist *& list)
 
 	if (!win)
 		return -3;
-
-	return 0;
 	*/
+	return 0;
 }
 
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -213,6 +213,7 @@ bool		Control::finish()
 {
 	// FIXME: this function must die
 	assert(0);
+	return false;
 
 	/*
 	mpd_finishCommand(conn->h());

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -159,9 +159,8 @@ List::move(uint32_t from, uint32_t to)
 		qnum = 0;
 		qsize = 0;
 	}
-
-	return true;
 	*/
+	return true;
 }
 
 ListItem *

--- a/src/pms.cpp
+++ b/src/pms.cpp
@@ -180,8 +180,9 @@ Pms::set_active_playback_list(Songlist * list)
 {
 	assert(list);
 
-	comm->activatelist(list);
+	bool ret = comm->activatelist(list);
 	drawstatus();
+	return ret;
 }
 
 void


### PR DESCRIPTION
There a couple of non void function without return.
Mostly this is not very important, but rpmlint throws errors because of it.

And for Pms::set_active_playback_list I think it is a bug.