### PR TITLE
Fix field formatter issue

### DIFF
--- a/src/field.cpp
+++ b/src/field.cpp
@@ -155,6 +155,8 @@ Item			Formatter::field_to_item(string f)
 	else if (f == "performer")
 		return FIELD_PERFORMER;
 	else if (f == "disc")
+		return FIELD_DISC;
+	else if (f == "comment")
 		return FIELD_COMMENT;
 
 	/* Conditionals */


### PR DESCRIPTION
Disc was being interpreted as a comment, and comment was not being intepreted.

I'm not 100% sure of this, so please check it. I just came across the code and it didn't look right.