### PR TITLE
Fix segfault adding album of last song on playlist

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1646,7 +1646,7 @@ int		multiplay(long mode, int playmode)
 			{
 				//last track of the current playlist is part of this album
 				//get last track of the album
-				item = list->match(pattern, 0, list->size() - 1, mode | MATCH_EXACT | MATCH_REVERSE);
+				item = list->match(pattern, list->size() - 1, 0, mode | MATCH_EXACT | MATCH_REVERSE);
 				song = LISTITEMSONG(item)->song;
 				if (playlist->match(song->file, playlist->size() - 1, playlist->size() - 1, MATCH_FILE | MATCH_EXACT))
 				{


### PR DESCRIPTION
When adding an album, the last song on the playlist is checked to see if it's the same album as that which is being added. If it is, we check if the last song on the playlist is the last song on the album.
(If it is, we add the entire album, otherwise we add just the remainder of the album.)

To do this we need to know what the last song of the album is. The search for the this looks through the entire library, and is meant to go from end to start. It was in fact starting from the first song in the library and going backwards from there, but the index to stop at was 0 so only the very first song of the source list was being checked.

Solution is to switch the start and stop index arguments in this case.

Closes #37