### PR TITLE
Fix next-of and prev-of

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -492,7 +492,7 @@ List::selection_rend()
 }
 
 ListItem *
-List::match(string pattern, unsigned int from, unsigned int to, long flags)
+List::match(string pattern, unsigned int from, unsigned int to, long flags, unsigned int * match_index)
 {
 	ListItem * it;
 	unsigned int i;
@@ -513,6 +513,7 @@ List::match(string pattern, unsigned int from, unsigned int to, long flags)
 		assert(it);
 
 		if (it->match(pattern, flags)) {
+			if (match_index != NULL) *match_index = i;
 			return it;
 		}
 
@@ -534,7 +535,7 @@ List::match(string pattern, unsigned int from, unsigned int to, long flags)
 }
 
 ListItem *
-List::match_wrap_around(string pattern, unsigned int from, long flags)
+List::match_wrap_around(string pattern, unsigned int from, long flags, unsigned int * match_index)
 {
 	unsigned int to;
 
@@ -550,5 +551,5 @@ List::match_wrap_around(string pattern, unsigned int from, long flags)
 		to = (from == 0 ? size() : from) - 1;
 	}
 
-	return match(pattern, from, to, flags);
+	return match(pattern, from, to, flags, match_index);
 }

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -495,7 +495,7 @@ ListItem *
 List::match(string pattern, unsigned int from, unsigned int to, long flags)
 {
 	ListItem * it;
-	int i;
+	unsigned int i;
 
 	if (!size()) {
 		return NULL;
@@ -508,12 +508,6 @@ List::match(string pattern, unsigned int from, unsigned int to, long flags)
 
 	while (true)
 	{
-		if (i < 0) {
-			i = size() - 1;
-		} else if (i >= size()) {
-			i = 0;
-		}
-
 		it = item(i);
 
 		assert(it);
@@ -526,37 +520,34 @@ List::match(string pattern, unsigned int from, unsigned int to, long flags)
 			break;
 		}
 
-		i += (flags & MATCH_REVERSE ? -1 : 1);
+		/* Next i, and wrap around ends of list */
+		if (flags & MATCH_REVERSE) {
+			if (i == 0) i = size();
+			i--;
+		} else {
+			i++;
+			if (i >= size()) i = 0;
+		}
 	}
 
 	return NULL;
 }
 
 ListItem *
-List::match_wrap_around(string pattern, int32_t from, long flags)
+List::match_wrap_around(string pattern, unsigned int from, long flags)
 {
-	int32_t to;
+	unsigned int to;
 
 	if (!size()) {
 		return NULL;
 	}
 
-	if (!(flags & MATCH_REVERSE)) {
-		if (from >= size()) {
-			from = 0;
-		}
-		to = from - 1;
-		if (to < 0) {
-			to = size() - 1;
-		}
+	assert(from < size());
+
+	if (flags & MATCH_REVERSE) {
+		to = (from + 1) % size();
 	} else {
-		if (from < 0) {
-			from = size() - 1;
-		}
-		to = from + 1;
-		if (to >= size()) {
-			to = 0;
-		}
+		to = (from == 0 ? size() : from) - 1;
 	}
 
 	return match(pattern, from, to, flags);

--- a/src/list.h
+++ b/src/list.h
@@ -155,7 +155,7 @@ public:
 	 *
 	 * Returns a ListItem pointer if a match was found, or NULL if no match.
 	 */
-	ListItem *			match(string pattern, unsigned int from, unsigned int to, long flags);
+	ListItem *			match(string pattern, unsigned int from, unsigned int to, long flags, unsigned int * match_index = NULL);
 
 	/**
 	 * Find matching ListItem, starting from after the cursor position,
@@ -163,7 +163,7 @@ public:
 	 *
 	 * Returns a ListItem pointer if a match was found, or NULL if no match.
 	 */
-	ListItem *			match_wrap_around(string pattern, unsigned int from, long flags);
+	ListItem *			match_wrap_around(string pattern, unsigned int from, long flags, unsigned int * match_index = NULL);
 
 	/**
 	 * Return the absolute position of the list item visible in the top of

--- a/src/list.h
+++ b/src/list.h
@@ -163,7 +163,7 @@ public:
 	 *
 	 * Returns a ListItem pointer if a match was found, or NULL if no match.
 	 */
-	ListItem *			match_wrap_around(string pattern, int32_t from, long flags);
+	ListItem *			match_wrap_around(string pattern, unsigned int from, long flags);
 
 	/**
 	 * Return the absolute position of the list item visible in the top of

--- a/src/songlist.cpp
+++ b/src/songlist.cpp
@@ -251,7 +251,7 @@ song_t		Songlist::findentry(Item field, bool reverse)
 	cmp[0] = pms->formatter->format(s, field, true);
 
 	/* Perform a match */
-	it = match(cmp[0], i, i - 1, mode | MATCH_NOT | MATCH_EXACT);
+	it = match_wrap_around(cmp[0], (unsigned int) i, mode | MATCH_NOT | MATCH_EXACT);
 	if (!it) {
 		pms->log(MSG_DEBUG, 0, "gotonextentry() fails with mode = %d\n", mode);
 		return MPD_SONG_NO_NUM;

--- a/src/songlist.cpp
+++ b/src/songlist.cpp
@@ -234,6 +234,7 @@ song_t		Songlist::findentry(Item field, bool reverse)
 //	string		where;
 	string		cmp[2];
 	bool		tmp;
+	unsigned int	match_index;
 
 	if (field == LITERALPERCENT || field == EINVALID) return i;
 
@@ -251,22 +252,21 @@ song_t		Songlist::findentry(Item field, bool reverse)
 	cmp[0] = pms->formatter->format(s, field, true);
 
 	/* Perform a match */
-	it = match_wrap_around(cmp[0], (unsigned int) i, mode | MATCH_NOT | MATCH_EXACT);
+	it = match_wrap_around(cmp[0], (unsigned int) i, mode | MATCH_NOT | MATCH_EXACT, &match_index);
 	if (!it) {
 		pms->log(MSG_DEBUG, 0, "gotonextentry() fails with mode = %d\n", mode);
 		return MPD_SONG_NO_NUM;
 	}
 
 	s = LISTITEMSONG(it)->song;
+	i = match_index;
 
 	/* Reverse match must match first entry, not last */
 	if (reverse)
 	{
 		cmp[0] = pms->formatter->format(s, field, true);
-		it = match_wrap_around(cmp[0], i, mode | MATCH_NOT | MATCH_EXACT);
-		if (it && it == last()) {
-			i = 0;
-		}
+		it = match_wrap_around(cmp[0], match_index, mode | MATCH_NOT | MATCH_EXACT, &match_index);
+		i = (match_index + 1) % size();
 	}
 
 	return i;

--- a/src/songlist.cpp
+++ b/src/songlist.cpp
@@ -263,7 +263,7 @@ song_t		Songlist::findentry(Item field, bool reverse)
 	if (reverse)
 	{
 		cmp[0] = pms->formatter->format(s, field, true);
-		it = match(cmp[0], i, i - 1, mode | MATCH_NOT | MATCH_EXACT);
+		it = match_wrap_around(cmp[0], i, mode | MATCH_NOT | MATCH_EXACT);
 		if (it && it == last()) {
 			i = 0;
 		}


### PR DESCRIPTION
My C++ is weak. There were `song_t`, `unsigned int` and `int32_t` all being thrown around in the same contexts, which led to some confusion. To try to tidy that up I've tried to change them all to `unsigned int` in the context of these `match` and `match_wrap_around` methods.

With that out of the way (and I haven't seen any problems yet but haven't thoroughly tested) I've added an optional argument to `List`'s `match` and `match_wrap_around` where a pointer to an unsigned int can be given. If a match is found, the value of the index where the match was found is assigned.

This index was important for `next-of` and `prev-of`, and disappeared during refactoring some time ago (perhaps in 405146e8b082138c837f49402bf0847094ebda04).

This fixes #46.