### PR TITLE
Make command-line host and port options override env vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,8 +19,8 @@ var buildVersion = "undefined"
 type cliOptions struct {
 	Version     bool   `short:"v" long:"version" description:"Print program version"`
 	Debug       string `short:"d" long:"debug" description:"Write debugging info to file"`
-	MpdHost     string `long:"host" description:"MPD host (MPD_HOST environment variable)" default:"localhost"`
-	MpdPort     string `long:"port" description:"MPD port (MPD_PORT environment variable)" default:"6600"`
+	MpdHost     string `long:"host" description:"MPD host" default-mask:"MPD_HOST environment variable or localhost"`
+	MpdPort     string `long:"port" description:"MPD port" default-mask:"MPD_PORT environment variable or 6600"`
 	MpdPassword string `long:"password" description:"MPD password"`
 }
 
@@ -54,13 +54,21 @@ func main() {
 
 	console.Log("Starting Practical Music Search.")
 
-	val, ok := os.LookupEnv("MPD_HOST")
-	if ok {
-		opts.MpdHost = val
+	if len(opts.MpdHost) == 0 {
+		val, ok := os.LookupEnv("MPD_HOST")
+		if ok {
+			opts.MpdHost = val
+		} else {
+			opts.MpdHost = "localhost"
+		}
 	}
-	val, ok = os.LookupEnv("MPD_PORT")
-	if ok {
-		opts.MpdPort = val
+	if len(opts.MpdPort) == 0 {
+		val, ok := os.LookupEnv("MPD_PORT")
+		if ok {
+			opts.MpdPort = val
+		} else {
+			opts.MpdPort = "6600"
+		}
 	}
 
 	pms := pms.New()


### PR DESCRIPTION
We still fall back to localhost and 6600 if neither exists.

Closes ambientsound/pms#61