### PR TITLE
Add originalyear field

### DIFF
--- a/options/defaults.go
+++ b/options/defaults.go
@@ -25,6 +25,7 @@ style time darkmagenta
 style title white bold
 style track green
 style year green
+style originalyear darkgreen
 
 # Tracklist styles
 style allTagsMissing red

--- a/song/song.go
+++ b/song/song.go
@@ -82,6 +82,10 @@ func (s *Song) AutoFill() {
 		s.Tags["year"] = s.Tags["date"][:4]
 		s.StringTags["year"] = string(s.Tags["year"])
 	}
+	if len(s.Tags["originaldate"]) >= 4 {
+		s.Tags["originalyear"] = s.Tags["originaldate"][:4]
+		s.StringTags["originalyear"] = string(s.Tags["originalyear"])
+	}
 }
 
 // FillSortTags post-processes tags, and saves them as strings for sorting purposes later on.


### PR DESCRIPTION
This is a virtual tag like 'year', and takes the first four characters
of the originaldate tag.

Closes ambientsound/pms#68