### PR TITLE
Add elapsed|percentage topbar field

### DIFF
--- a/doc/styling.md
+++ b/doc/styling.md
@@ -23,7 +23,8 @@ Any _tag_, such as `artist`, `album`, `date`, `time`, etc. can be styled. These 
 
 Please see [top bar](#top-bar) for corresponding variables.
 
-* `elapsed` - corresponds to `${elapsed}`.
+* `elapsedPercentage` - corresponds to `${elapsed|percentage}`.
+* `elapsedTime` - corresponds to `${elapsed}`.
 * `listIndex` - corresponds to `${list|index}`.
 * `listTitle` - corresponds to `${list|title}`.
 * `listTotal` - corresponds to `${list|total}`.
@@ -97,7 +98,9 @@ set topbar=";|the ${tag|artist} is in the center||;;"
 
 ### Variables
 
-* `${elapsed}` is the time elapsed in the current track.
+* `${elapsed}`
+    * `${elapsed}` is the time elapsed in the current track.
+    * `${elapsed|percentage}` is the time elapsed in the current track as a percentage of its total length.
 * `${list}`
     * `${list|index}` is the numeric index of the current tracklist.
     * `${list|title}` is the title of the current tracklist.

--- a/mpd/playerstatus.go
+++ b/mpd/playerstatus.go
@@ -4,22 +4,23 @@ import "time"
 
 // PlayerStatus contains information about MPD's player status.
 type PlayerStatus struct {
-	Audio          string
-	Bitrate        int
-	Consume        bool
-	Elapsed        float64
-	Err            string
-	MixRampDB      float64
-	Playlist       int
-	PlaylistLength int
-	Random         bool
-	Repeat         bool
-	Single         bool
-	Song           int
-	SongID         int
-	State          string
-	Time           int
-	Volume         int
+	Audio             string
+	Bitrate           int
+	Consume           bool
+	Elapsed           float64
+	ElapsedPercentage float64
+	Err               string
+	MixRampDB         float64
+	Playlist          int
+	PlaylistLength    int
+	Random            bool
+	Repeat            bool
+	Single            bool
+	Song              int
+	SongID            int
+	State             string
+	Time              int
+	Volume            int
 
 	updateTime time.Time
 }
@@ -47,4 +48,9 @@ func (p *PlayerStatus) Tick() {
 	diff := p.Since()
 	p.SetTime()
 	p.Elapsed += diff.Seconds()
+	if p.Time == 0 {
+		p.ElapsedPercentage = 0.0
+	} else {
+		p.ElapsedPercentage = float64(100) * p.Elapsed / float64(p.Time)
+	}
 }

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -35,7 +35,8 @@ style mostTagsMissing red
 style selection white blue
 
 # Topbar styles
-style elapsed green
+style elapsedTime green
+style elapsedPercentage green
 style listIndex darkblue
 style listTitle blue bold
 style listTotal darkblue

--- a/pms/pms.go
+++ b/pms/pms.go
@@ -569,6 +569,7 @@ func (pms *PMS) UpdatePlayerStatus() error {
 	pms.mpdStatus.Volume, _ = strconv.Atoi(attrs["volume"])
 
 	pms.mpdStatus.Elapsed, _ = strconv.ParseFloat(attrs["elapsed"], 64)
+	pms.mpdStatus.ElapsedPercentage, _ = strconv.ParseFloat(attrs["elapsedpercentage"], 64)
 	pms.mpdStatus.MixRampDB, _ = strconv.ParseFloat(attrs["mixrampdb"], 64)
 
 	pms.mpdStatus.Consume, _ = strconv.ParseBool(attrs["consume"])

--- a/topbar/elapsed.go
+++ b/topbar/elapsed.go
@@ -1,6 +1,8 @@
 package topbar
 
 import (
+	"fmt"
+
 	"github.com/ambientsound/pms/api"
 	"github.com/ambientsound/pms/utils"
 )
@@ -8,15 +10,32 @@ import (
 // Elapsed draws the current song's elapsed time.
 type Elapsed struct {
 	api api.API
+	f   func() (string, string)
 }
 
 // NewElapsed returns Elapsed.
 func NewElapsed(a api.API, param string) Fragment {
-	return &Elapsed{a}
+	elapsed := &Elapsed{a, nil}
+	switch param {
+	case `percentage`:
+		elapsed.f = elapsed.textPercentage
+	default:
+		elapsed.f = elapsed.textTime
+	}
+	return elapsed
 }
 
 // Text implements Fragment.
 func (w *Elapsed) Text() (string, string) {
+	return w.f()
+}
+
+func (w *Elapsed) textTime() (string, string) {
 	playerStatus := w.api.PlayerStatus()
-	return utils.TimeString(int(playerStatus.Elapsed)), `elapsed`
+	return utils.TimeString(int(playerStatus.Elapsed)), `elapsedTime`
+}
+
+func (w *Elapsed) textPercentage() (string, string) {
+	playerStatus := w.api.PlayerStatus()
+	return fmt.Sprintf("%d", int(playerStatus.ElapsedPercentage)), `elapsedPercentage`
 }


### PR DESCRIPTION
As part of this, the `elapsed` colour variable is renamed from
`elapsed` to `elapsedTime`, to make way for `elapsedPercentage` to go
alongside it. (The `elapsed` topbar field stays as is.)

Closes ambientsound/pms#70