### PR TITLE
Add zb, zz, zt equivalents

### DIFF
--- a/commands/viewport.go
+++ b/commands/viewport.go
@@ -48,6 +48,12 @@ func (cmd *Viewport) Parse() error {
 		cmd.scrollFullPage(1)
 	case "pgup", "pageup":
 		cmd.scrollFullPage(-1)
+	case "high":
+		cmd.scrollToCursorAnchor(-1)
+	case "middle":
+		cmd.scrollToCursorAnchor(0)
+	case "low":
+		cmd.scrollToCursorAnchor(1)
 	default:
 		return fmt.Errorf("Viewport command '%s' not recognized", lit)
 	}
@@ -87,6 +93,27 @@ func (cmd *Viewport) scrollFullPage(direction int) {
 	cmd.movecursor = false
 }
 
+// scrollToCursorAnchor configures the command to scroll to a point
+// such that the cursor is left at the top, middle, or bottom.
+// The position parameter must be
+// positive to move the viewport low (scrolled further down; cursor high),
+// zero to leave it in the middle,
+// or negative to move the viewport high (scrolled further up; cursor low).
+func (cmd *Viewport) scrollToCursorAnchor(position int) {
+	widget := cmd.api.SonglistWidget()
+	ymin, ymax := widget.GetVisibleBoundaries()
+	cursor := widget.Songlist().Cursor()
+	if position < 0 {
+		cmd.relative = cursor - ymax
+	} else if position > 0 {
+		cmd.relative = cursor - ymin
+	} else {
+		_, y := widget.Size()
+		cmd.relative = cursor - y/2 - ymin
+	}
+	cmd.movecursor = false
+}
+
 // Exec implements Command.
 func (cmd *Viewport) Exec() error {
 	widget := cmd.api.SonglistWidget()
@@ -105,6 +132,9 @@ func (cmd *Viewport) setTabCompleteVerbs(lit string) {
 		"halfpageup",
 		"halfpgdn",
 		"halfpgup",
+		"high",
+		"low",
+		"middle",
 		"pagedn",
 		"pagedown",
 		"pageup",

--- a/commands/viewport_test.go
+++ b/commands/viewport_test.go
@@ -21,6 +21,9 @@ var viewportTests = []commands.Test{
 	//{`halfpageup`, true},
 	//{`halfpagedn`, true},
 	//{`halfpagedown`, true},
+	//{`high`, true},
+	//{`middle`, true},
+	//{`low`, true},
 
 	// Invalid forms
 	{`up 1`, false, nil, nil, []string{}},
@@ -36,6 +39,9 @@ var viewportTests = []commands.Test{
 	//{`halfpageup 1`, false},
 	//{`halfpagedn 1`, false},
 	//{`halfpagedown 1`, false},
+	//{`high 1`, false},
+	//{`middle 1`, false},
+	//{`low 1`, false},
 	{`nonsense`, false, nil, nil, []string{}},
 
 	// Tab completion
@@ -46,6 +52,9 @@ var viewportTests = []commands.Test{
 		"halfpageup",
 		"halfpgdn",
 		"halfpgup",
+		"high",
+		"low",
+		"middle",
 		"pagedn",
 		"pagedown",
 		"pageup",

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -89,6 +89,17 @@ These commands are split into `cursor` and `viewport` namespaces.
   Move the viewport up or down one full page (actually slightly less in most cases),
   leaving the cursor on its current song where possible.
 
+* `viewport high`  
+  `viewport low`
+
+  Move the viewport up as high or as low as possible while leaving the cursor in view,
+  still pointing to the same song.
+  (When `center` is set the cursor will not end up pointing to the same song.)
+
+* `viewport middle`
+
+  Move the viewport so that the cursor is in the middle of the viewport,
+  still pointing to the same song.
 
 ## Manipulating lists
 

--- a/options/defaults.go
+++ b/options/defaults.go
@@ -84,6 +84,12 @@ bind e cursor nextOf album
 bind H cursor high
 bind M cursor middle
 bind L cursor low
+bind zb viewport high
+bind z- viewport high
+bind zz viewport middle
+bind z. viewport middle
+bind zt viewport low
+bind z<Enter> viewport low
 
 # Keyboard bindings: input mode
 bind : inputmode input


### PR DESCRIPTION
These commands move the viewport but leave the cursor in place. Respectively they move the viewport so that the cursor is at the bottom, in the centre, and at the top, and are called viewport high, middle, and low.

Closes #77

I've based this atop #96, since there's some overlap.