### PR TITLE
Move Bleve search index data from singleton to songlist.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,7 +3,6 @@ package api
 
 import (
 	"github.com/ambientsound/gompd/mpd"
-	"github.com/ambientsound/pms/index"
 	"github.com/ambientsound/pms/input/keys"
 	"github.com/ambientsound/pms/message"
 	pms_mpd "github.com/ambientsound/pms/mpd"
@@ -19,8 +18,8 @@ type API interface {
 	// Clipboard returns the default clipboard.
 	Clipboard() songlist.Songlist
 
-	// Index returns the current Bleve search index, or nil if the search index is not available.
-	Index() *index.Index
+	// Library returns the current MPD library, or nil if it has not been retrieved yet.
+	Library() *songlist.Library
 
 	// ListChanged notifies the UI that the current songlist has changed.
 	ListChanged()
@@ -75,7 +74,7 @@ type baseAPI struct {
 	eventList      chan int
 	eventMessage   chan message.Message
 	eventOption    chan string
-	index          func() *index.Index
+	library        func() *songlist.Library
 	mpdClient      func() *mpd.Client
 	multibar       func() MultibarWidget
 	options        *options.Options
@@ -94,7 +93,7 @@ func BaseAPI(
 	eventList chan int,
 	eventMessage chan message.Message,
 	eventOption chan string,
-	index func() *index.Index,
+	library func() *songlist.Library,
 	mpdClient func() *mpd.Client,
 	multibar func() MultibarWidget,
 	options *options.Options,
@@ -113,9 +112,9 @@ func BaseAPI(
 		eventList:      eventList,
 		eventMessage:   eventMessage,
 		eventOption:    eventOption,
-		index:          index,
 		mpdClient:      mpdClient,
 		multibar:       multibar,
+		library:        library,
 		options:        options,
 		playerStatus:   playerStatus,
 		queue:          queue,
@@ -132,8 +131,8 @@ func (api *baseAPI) Clipboard() songlist.Songlist {
 	return api.clipboard()
 }
 
-func (api *baseAPI) Index() *index.Index {
-	return api.index()
+func (api *baseAPI) Library() *songlist.Library {
+	return api.library()
 }
 
 func (api *baseAPI) ListChanged() {

--- a/api/test_api.go
+++ b/api/test_api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"github.com/ambientsound/gompd/mpd"
-	"github.com/ambientsound/pms/index"
 	"github.com/ambientsound/pms/input/keys"
 	"github.com/ambientsound/pms/message"
 	pms_mpd "github.com/ambientsound/pms/mpd"
@@ -43,8 +42,8 @@ func (api *testAPI) Clipboard() songlist.Songlist {
 	return api.clipboard
 }
 
-func (api *testAPI) Index() *index.Index {
-	return nil
+func (api *testAPI) Library() *songlist.Library {
+	return nil // FIXME
 }
 
 func (api *testAPI) ListChanged() {

--- a/commands/isolate.go
+++ b/commands/isolate.go
@@ -32,9 +32,9 @@ func (cmd *Isolate) Parse() error {
 
 // Exec implements Command.
 func (cmd *Isolate) Exec() error {
-	index := cmd.api.Index()
-	if index == nil {
-		return fmt.Errorf("Search index is not operational.")
+	library := cmd.api.Library()
+	if library == nil {
+		return fmt.Errorf("Song library is not present.")
 	}
 
 	songlistWidget := cmd.api.SonglistWidget()
@@ -46,7 +46,7 @@ func (cmd *Isolate) Exec() error {
 		return fmt.Errorf("Isolate needs at least one track.")
 	}
 
-	result, err := index.Isolate(selection, cmd.tags)
+	result, err := library.Isolate(selection, cmd.tags)
 	if err != nil {
 		return err
 	}

--- a/index/index.go
+++ b/index/index.go
@@ -1,11 +1,15 @@
 package index
 
 import (
-	"strings"
+	"bufio"
+	"os"
+	"path"
+	"time"
 
 	"github.com/ambientsound/pms/console"
 	index_song "github.com/ambientsound/pms/index/song"
-	"github.com/ambientsound/pms/songlist"
+	"github.com/ambientsound/pms/song"
+	"github.com/ambientsound/pms/xdg"
 
 	"github.com/blevesearch/bleve"
 
@@ -19,59 +23,161 @@ const SEARCH_SCORE_THRESHOLD float64 = 0.5
 
 type Index struct {
 	bleveIndex bleve.Index
-	Songlist   songlist.Songlist
+	path       string
+	indexPath  string
+	statePath  string
+	version    int
 }
 
-func New(loc string, s songlist.Songlist) (*Index, error) {
+func createDirectory(dir string) error {
+	dirMode := os.ModeDir | 0755
+	return os.MkdirAll(dir, dirMode)
+}
+
+// New opens a Bleve index and returns Index. In case an index is not found at
+// the given path, a new one is created. In case of an error, nil is returned,
+// and the error object set accordingly.
+func New(basePath string) (*Index, error) {
 	var err error
+
+	timer := time.Now()
+
+	err = createDirectory(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("while creating %s: %s", basePath, err)
+	}
+
 	i := &Index{}
-	i.bleveIndex, err = i.open(loc)
-	if err != nil {
-		i.bleveIndex, err = i.create(loc)
+	i.path = basePath
+	i.indexPath = path.Join(i.path, "index")
+	i.statePath = path.Join(i.path, "state")
+
+	// Try to stat the Bleve index path. If it does not exist, create it.
+	if _, err := os.Stat(i.indexPath); err != nil {
+		if os.IsNotExist(err) {
+			i.bleveIndex, err = create(i.indexPath)
+			if err != nil {
+				return nil, fmt.Errorf("while creating index at %s: %s", i.indexPath, err)
+			}
+
+			// After successful creation, reset the MPD library version.
+			err = i.SetVersion(0)
+			if err != nil {
+				return nil, fmt.Errorf("while zeroing out library version at %s: %s", i.statePath, err)
+			}
+
+		} else {
+			// In case of any other filesystem error, abort operation.
+			return nil, fmt.Errorf("while accessing %s: %s", i.indexPath, err)
+		}
+
+	} else {
+
+		// If index was statted ok, try to open it.
+		i.bleveIndex, err = open(i.indexPath)
+		if err != nil {
+			return nil, fmt.Errorf("while opening index at %s: %s", i.indexPath, err)
+		}
+		i.version, err = i.readVersion()
+		if err != nil {
+			console.Log("index state file is broken: %s", err)
+		}
 	}
-	i.Songlist = s
-	return i, err
+
+	console.Log("Opened search index in %s", time.Since(timer).String())
+
+	return i, nil
 }
 
-func (i *Index) create(loc string) (index bleve.Index, err error) {
-	mapping, err := buildIndexMapping()
-	if err != nil {
-		panic(err)
-	}
-	index, err = bleve.New(loc, mapping)
-	if err != nil {
-		console.Log("Error while creating index %s: %s", loc, err)
-	}
-	return
-}
-
-func (i *Index) open(loc string) (index bleve.Index, err error) {
-	index, err = bleve.Open(loc)
-	if err != nil {
-		console.Log("Cannot open index %s: %s", loc, err)
-	}
-	return
-}
-
+// Close closes a Bleve index.
 func (i *Index) Close() error {
 	return i.bleveIndex.Close()
 }
 
+// create creates a Bleve index at the given file system location.
+func create(path string) (bleve.Index, error) {
+	mapping, err := buildIndexMapping()
+	if err != nil {
+		return nil, fmt.Errorf("BUG: unable to create search index mapping: %s", err)
+	}
+
+	index, err := bleve.New(path, mapping)
+	if err != nil {
+		return nil, fmt.Errorf("while creating search index %s: %s", path, err)
+	}
+
+	return index, nil
+}
+
+// open opens a Bleve index at the given file system location.
+func open(path string) (bleve.Index, error) {
+	index, err := bleve.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("while opening search index %s: %s", path, err)
+	}
+
+	return index, nil
+}
+
+// Path returns the absolute path to where indexes and state for a specific MPD
+// server should be stored.
+func Path(host, port string) string {
+	cacheDir := xdg.CacheDirectory()
+	return path.Join(cacheDir, host, port)
+}
+
+// SetVersion writes the MPD library version to the state file.
+func (i *Index) SetVersion(version int) error {
+	file, err := os.Create(i.statePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	str := fmt.Sprintf("%d\n", version)
+	file.WriteString(str)
+	i.version = version
+	return nil
+}
+
+// readVersion reads the MPD library version from the state file.
+func (i *Index) readVersion() (int, error) {
+	file, err := os.Open(i.statePath)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		version, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return 0, err
+		}
+		return version, nil
+	}
+
+	return 0, fmt.Errorf("No data in index mpd library state file")
+}
+
+func (i *Index) Version() int {
+	return i.version
+}
+
 // Index the entire Songlist.
-func (i *Index) IndexFull() error {
+func (i *Index) IndexFull(songs []*song.Song) error {
 	var err error
 
 	// All operations are batched, currently INDEX_BATCH_SIZE are committed each iteration.
 	b := i.bleveIndex.NewBatch()
 
-	for pos, s := range i.Songlist.Songs() {
+	for pos, s := range songs {
 		is := index_song.New(s)
 		err = b.Index(strconv.Itoa(pos), is)
 		if err != nil {
 			return err
 		}
 		if pos%INDEX_BATCH_SIZE == 0 {
-			console.Log("Indexing songs %d/%d...", pos, i.Songlist.Len())
+			console.Log("Indexing songs %d/%d...", pos, len(songs))
 			i.bleveIndex.Batch(b)
 			b.Reset()
 		}
@@ -86,69 +192,70 @@ func (i *Index) IndexFull() error {
 
 // Search takes a natural language query string, matches it against the search
 // index, and returns a new Songlist with all matching songs.
-func (i *Index) Search(q string) (songlist.Songlist, error) {
+func (i *Index) Search(q string, size int) ([]int, error) {
 	query := bleve.NewQueryStringQuery(q)
 	request := bleve.NewSearchRequest(query)
+	request.Size = size
 
 	r, _, err := i.Query(request)
-	r.SetName(q)
 
 	return r, err
 }
 
-// Isolate takes a songlist and a set of tag keys, and matches the tag values
-// of the songlist against the search index.
-func (i *Index) Isolate(list songlist.Songlist, tags []string) (songlist.Songlist, error) {
-	terms := make(map[string]struct{})
-	query := bleve.NewBooleanQuery()
-	songs := list.Songs()
+//// Isolate takes a songlist and a set of tag keys, and matches the tag values
+//// of the songlist against the search index.
+//func (i *Index) Isolate(list songlist.Songlist, tags []string) (songlist.Songlist, error) {
+//terms := make(map[string]struct{})
+//query := bleve.NewBooleanQuery()
+//songs := list.Songs()
 
-	// Create a cartesian join for song values and tag list.
-	for _, song := range songs {
-		subQuery := bleve.NewConjunctionQuery()
+//// Create a cartesian join for song values and tag list.
+//for _, song := range songs {
+//subQuery := bleve.NewConjunctionQuery()
 
-		for _, tag := range tags {
+//for _, tag := range tags {
 
-			// Ignore empty values
-			tagValue := song.StringTags[tag]
-			if len(tagValue) == 0 {
-				continue
-			}
+//// Ignore empty values
+//tagValue := song.StringTags[tag]
+//if len(tagValue) == 0 {
+//continue
+//}
 
-			// Name generation
-			terms[tagValue] = struct{}{}
+//// Name generation
+//terms[tagValue] = struct{}{}
 
-			field := strings.Title(tag)
-			query := bleve.NewMatchPhraseQuery(tagValue)
-			query.SetField(field)
-			subQuery.AddQuery(query)
-		}
-		query.AddShould(subQuery)
-	}
+//field := strings.Title(tag)
+//query := bleve.NewMatchPhraseQuery(tagValue)
+//query.SetField(field)
+//subQuery.AddQuery(query)
+//}
+//query.AddShould(subQuery)
+//}
 
-	request := bleve.NewSearchRequest(query)
-	r, _, err := i.Query(request)
+//request := bleve.NewSearchRequest(query)
+//r, _, err := i.Query(request)
 
-	names := make([]string, 0)
-	for k := range terms {
-		names = append(names, k)
-	}
-	name := strings.Join(names, ", ")
-	r.SetName(name)
+//names := make([]string, 0)
+//for k := range terms {
+//names = append(names, k)
+//}
+//name := strings.Join(names, ", ")
+//r.SetName(name)
 
-	return r, err
-}
+//return r, err
+//}
 
 // Query takes a Bleve search request and returns a songlist with all matching songs.
-func (i *Index) Query(request *bleve.SearchRequest) (songlist.Songlist, *bleve.SearchResult, error) {
-	r := songlist.New()
-	request.Size = i.Songlist.Len()
+func (i *Index) Query(request *bleve.SearchRequest) ([]int, *bleve.SearchResult, error) {
+	//request.Size = 1000
 
 	sr, err := i.bleveIndex.Search(request)
 
 	if err != nil {
-		return r, nil, err
+		return make([]int, 0), nil, err
 	}
+
+	r := make([]int, 0, len(sr.Hits))
 
 	for _, hit := range sr.Hits {
 		if hit.Score < SEARCH_SCORE_THRESHOLD {
@@ -156,14 +263,12 @@ func (i *Index) Query(request *bleve.SearchRequest) (songlist.Songlist, *bleve.S
 		}
 		id, err := strconv.Atoi(hit.ID)
 		if err != nil {
-			panic(fmt.Sprintf("Error when converting index IDs to integer: %s", err))
+			return r, nil, fmt.Errorf("Index is corrupt; error when converting index IDs to integer: %s", err)
 		}
-		song := i.Songlist.Song(id)
-		r.Add(song)
-		//console.Log("%.2f %s\n", hit.Score, song.Tags["file"])
+		r = append(r, id)
 	}
 
-	console.Log("Query '%s' returned %d results over threshold of %.2f (total %d results) in %s", request, r.Len(), SEARCH_SCORE_THRESHOLD, sr.Total, sr.Took)
+	console.Log("Query '%s' returned %d results over threshold of %.2f (total %d results) in %s", request, len(r), SEARCH_SCORE_THRESHOLD, sr.Total, sr.Took)
 
 	return r, sr, nil
 }

--- a/index/index.go
+++ b/index/index.go
@@ -220,61 +220,6 @@ outer:
 	return nil
 }
 
-// Search takes a natural language query string, matches it against the search
-// index, and returns a new Songlist with all matching songs.
-func (i *Index) Search(q string, size int) ([]int, error) {
-	query := bleve.NewQueryStringQuery(q)
-	request := bleve.NewSearchRequest(query)
-	request.Size = size
-
-	r, _, err := i.Query(request)
-
-	return r, err
-}
-
-//// Isolate takes a songlist and a set of tag keys, and matches the tag values
-//// of the songlist against the search index.
-//func (i *Index) Isolate(list songlist.Songlist, tags []string) (songlist.Songlist, error) {
-//terms := make(map[string]struct{})
-//query := bleve.NewBooleanQuery()
-//songs := list.Songs()
-
-//// Create a cartesian join for song values and tag list.
-//for _, song := range songs {
-//subQuery := bleve.NewConjunctionQuery()
-
-//for _, tag := range tags {
-
-//// Ignore empty values
-//tagValue := song.StringTags[tag]
-//if len(tagValue) == 0 {
-//continue
-//}
-
-//// Name generation
-//terms[tagValue] = struct{}{}
-
-//field := strings.Title(tag)
-//query := bleve.NewMatchPhraseQuery(tagValue)
-//query.SetField(field)
-//subQuery.AddQuery(query)
-//}
-//query.AddShould(subQuery)
-//}
-
-//request := bleve.NewSearchRequest(query)
-//r, _, err := i.Query(request)
-
-//names := make([]string, 0)
-//for k := range terms {
-//names = append(names, k)
-//}
-//name := strings.Join(names, ", ")
-//r.SetName(name)
-
-//return r, err
-//}
-
 // Query takes a Bleve search request and returns a songlist with all matching songs.
 func (i *Index) Query(request *bleve.SearchRequest) ([]int, *bleve.SearchResult, error) {
 	//request.Size = 1000

--- a/index/index.go
+++ b/index/index.go
@@ -159,6 +159,7 @@ func (i *Index) readVersion() (int, error) {
 	return 0, fmt.Errorf("No data in index mpd library state file")
 }
 
+// Version returns the index version. It should correspond to the MPD library version.
 func (i *Index) Version() int {
 	return i.version
 }
@@ -174,6 +175,8 @@ func (i *Index) IndexFull(songs []*song.Song, shutdown <-chan int) error {
 	return fullIndex(i.bleveIndex, songChan, shutdown)
 }
 
+// fullIndex indexes a stream of songs. This process can be aborted by sending
+// a message on the shutdown channel.
 func fullIndex(index bleve.Index, songs <-chan *song.Song, shutdown <-chan int) error {
 	var err error
 

--- a/pms/main.go
+++ b/pms/main.go
@@ -20,8 +20,6 @@ func (pms *PMS) Main() {
 			pms.handleEventLibrary()
 		case <-pms.EventQueue:
 			pms.handleEventQueue()
-		case <-pms.EventIndex:
-			pms.handleEventIndex()
 		case <-pms.EventList:
 			pms.handleEventList()
 		case <-pms.EventPlayer:
@@ -59,13 +57,6 @@ func (pms *PMS) handleEventQueue() {
 	console.Log("Queue updated in MPD, assigning to UI")
 	pms.ui.App.PostFunc(func() {
 		pms.ui.Songlist.ReplaceSonglist(pms.Queue)
-	})
-}
-
-func (pms *PMS) handleEventIndex() {
-	console.Log("Search index updated, assigning to UI")
-	pms.ui.App.PostFunc(func() {
-		pms.ui.SetIndex(pms.Index)
 	})
 }
 

--- a/pms/pms.go
+++ b/pms/pms.go
@@ -183,6 +183,11 @@ func (pms *PMS) CurrentMpdClient() *mpd.Client {
 	return client
 }
 
+// CurrentLibrary returns the MPD library.
+func (pms *PMS) CurrentLibrary() *songlist.Library {
+	return pms.Library
+}
+
 // CurrentQueue returns the queue songlist.
 func (pms *PMS) CurrentQueue() *songlist.Queue {
 	return pms.Queue
@@ -191,11 +196,6 @@ func (pms *PMS) CurrentQueue() *songlist.Queue {
 // CurrentPlayerStatus returns a copy of the current MPD player status as seen by PMS.
 func (pms *PMS) CurrentPlayerStatus() pms_mpd.PlayerStatus {
 	return pms.mpdStatus
-}
-
-// CurrentIndex returns the Bleve search index.
-func (pms *PMS) CurrentIndex() *index.Index {
-	return pms.Index
 }
 
 // CurrentSonglistWidget returns the current songlist.

--- a/pms/setup.go
+++ b/pms/setup.go
@@ -53,7 +53,7 @@ func (pms *PMS) API() api.API {
 		pms.EventList,
 		pms.EventMessage,
 		pms.EventOption,
-		pms.CurrentIndex,
+		pms.CurrentLibrary,
 		pms.CurrentMpdClient,
 		pms.Multibar,
 		pms.Options,

--- a/pms/setup.go
+++ b/pms/setup.go
@@ -18,7 +18,6 @@ import (
 func New() *PMS {
 	pms := &PMS{}
 
-	pms.EventIndex = make(chan int, 1024)
 	pms.EventLibrary = make(chan int, 1024)
 	pms.EventList = make(chan int, 1024)
 	pms.EventMessage = make(chan message.Message, 1024)

--- a/songlist/library.go
+++ b/songlist/library.go
@@ -2,11 +2,17 @@ package songlist
 
 import (
 	"fmt"
+	"time"
+
+	"github.com/ambientsound/pms/console"
+	"github.com/ambientsound/pms/index"
 )
 
 // Library is a Songlist which represents the MPD song library.
 type Library struct {
 	BaseSonglist
+	index   *index.Index
+	version int
 }
 
 func NewLibrary() (s *Library) {
@@ -43,6 +49,87 @@ func (s *Library) RemoveIndices(indices []int) error {
 	return fmt.Errorf("The song library is read-only.")
 }
 
+// OpenIndex configures the library to use the Bleve search index at the specified path.
+func (s *Library) OpenIndex(path string) error {
+	var err error
+
+	if s.HasIndex() {
+		if err = s.index.Close(); err != nil {
+			return err
+		}
+		s.index = nil
+	}
+
+	s.index, err = index.New(path)
+
+	return err
+}
+
+// CloseIndex closes the Bleve search index.
+func (s *Library) CloseIndex() error {
+	if s.HasIndex() {
+		return s.index.Close()
+	}
+	return nil
+}
+
+func (s *Library) HasIndex() bool {
+	return s.index != nil
+}
+
+func (s *Library) SetVersion(version int) {
+	s.version = version
+}
+
+func (s *Library) Version() int {
+	return s.version
+}
+
+func (s *Library) IndexSynced() bool {
+	return s.HasIndex() && s.index.Version() == s.version
+}
+
+// FIXME: ReIndex is not thread safe yet!!!
+func (s *Library) ReIndex() {
+	go func() {
+		timer := time.Now()
+		s.index.IndexFull(s.Songs())
+		s.index.SetVersion(s.Version())
+		console.Log("Song library index complete, took %s", time.Since(timer).String())
+	}()
+}
+
+// Search does a search in the Bleve index for a specific natural language
+// query string, and returns a new Songlist with the search results.
+func (s *Library) Search(q string) (Songlist, error) {
+	if s.index == nil {
+		return nil, fmt.Errorf("Search index is not open.")
+	}
+
+	ids, err := s.index.Search(q, s.Len())
+	if err != nil {
+		return nil, err
+	}
+
+	list := New()
+	list.SetName(q)
+	for _, id := range ids {
+		song := s.Song(id)
+		if song == nil {
+			return nil, fmt.Errorf("Search index is corrupt.")
+		}
+		list.Add(song)
+	}
+
+	return list, nil
+}
+
 func (s *Library) Isolate(list Songlist, tags []string) (Songlist, error) {
+	//names := make([]string, 0)
+	//for k := range terms {
+	//names = append(names, k)
+	//}
+	//name := strings.Join(names, ", ")
+	//r.SetName(name)
 	return nil, fmt.Errorf("NOT IMPLEMENTED")
 }

--- a/songlist/library.go
+++ b/songlist/library.go
@@ -42,3 +42,7 @@ func (s *Library) Remove(index int) error {
 func (s *Library) RemoveIndices(indices []int) error {
 	return fmt.Errorf("The song library is read-only.")
 }
+
+func (s *Library) Isolate(list Songlist, tags []string) (Songlist, error) {
+	return nil, fmt.Errorf("NOT IMPLEMENTED")
+}

--- a/songlist/selection.go
+++ b/songlist/selection.go
@@ -2,8 +2,6 @@ package songlist
 
 import (
 	"sort"
-
-	"github.com/ambientsound/pms/console"
 )
 
 // ManuallySelected returns true if the given song index is selected through manual selection.
@@ -78,15 +76,7 @@ func (s *BaseSonglist) ClearSelection() {
 // Selection returns the current selection as a new Songlist.
 func (s *BaseSonglist) Selection() Songlist {
 	indices := s.SelectionIndices()
-	dest := New()
-	for _, i := range indices {
-		if song := s.Song(i); song != nil {
-			dest.Add(song)
-		} else {
-			console.Log("SelectionIndices() returned an integer '%d' that resulted in a nil song, ignoring", i)
-		}
-	}
-	return dest
+	return s.Indices(indices)
 }
 
 // validateVisualSelection makes sure the visual selection stays in range of

--- a/songlist/songlist.go
+++ b/songlist/songlist.go
@@ -18,6 +18,7 @@ type Songlist interface {
 	Clear() error
 	Delete() error
 	Duplicate(Songlist) error
+	Indices([]int) Songlist
 	InRange(int) bool
 	Insert(*song.Song, int) error
 	InsertList(Songlist, int) error
@@ -241,6 +242,20 @@ func (s *BaseSonglist) Truncate(length int) error {
 	defer s.Unlock()
 	s.songs = s.songs[:length]
 	return nil
+}
+
+// Indices accepts a slice of integers pointing to song positions, returns a
+// new songlist with those songs. Any mismatching integers are ignored.
+func (s *BaseSonglist) Indices(indices []int) Songlist {
+	dest := New()
+	for _, i := range indices {
+		if song := s.Song(i); song != nil {
+			dest.Add(song)
+		} else {
+			console.Log("BUG: Indices() returned an integer '%d' that resulted in a nil song, ignoring", i)
+		}
+	}
+	return dest
 }
 
 func (s *BaseSonglist) Locate(match *song.Song) (int, error) {

--- a/widgets/ui.go
+++ b/widgets/ui.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ambientsound/pms/api"
 	"github.com/ambientsound/pms/console"
 	"github.com/ambientsound/pms/constants"
-	"github.com/ambientsound/pms/index"
 	"github.com/ambientsound/pms/options"
 	"github.com/ambientsound/pms/songlist"
 	"github.com/ambientsound/pms/style"
@@ -33,7 +32,6 @@ type UI struct {
 
 	// Data resources
 	api          api.API
-	Index        *index.Index
 	options      *options.Options // FIXME: use api instead
 	searchResult songlist.Songlist
 
@@ -93,10 +91,6 @@ func (ui *UI) CreateLayout() {
 
 func (ui *UI) Refresh() {
 	ui.App.Refresh()
-}
-
-func (ui *UI) SetIndex(i *index.Index) {
-	ui.Index = i
 }
 
 func (ui *UI) CurrentSonglistWidget() api.SonglistWidget {
@@ -219,11 +213,12 @@ func (ui *UI) refreshPositionReadout() {
 func (ui *UI) runIndexSearch(term string) error {
 	var err error
 
-	if ui.Index == nil {
-		return fmt.Errorf("Search index is not operational")
+	library := ui.api.Library()
+	if library == nil {
+		return fmt.Errorf("Song library is not present.")
 	}
 
-	ui.searchResult, err = ui.Index.Search(term)
+	ui.searchResult, err = library.Search(term)
 
 	ui.showSearchResult()
 


### PR DESCRIPTION
This patch brings a few important changes:

* Library indexing is asynchronous again.
* Overlapping library updates during indexing aborts the old indexing job, and starts a new one.
* Each songlist might potentionally have their own Bleve index.
* More code documentation.