### PR TITLE
Fix infinite loop if run without a controlling terminal

### DIFF
--- a/src/pms.cpp
+++ b/src/pms.cpp
@@ -471,7 +471,9 @@ Pms::main()
 		printf(_("This mpd server requires a password.\n"));
 		printf(_("Password: "));
 
-		fgets(pass, 512, stdin) ? 1 : 0; //ternary here is a hack to get rid of a warn_unused_result warning
+		if (fgets(pass, 512, stdin) == 0) {
+			return PMS_EXIT_BADPASS;
+		}
 		if (pass[strlen(pass)-1] == '\n') {
 			pass[strlen(pass)-1] = '\0';
 		}


### PR DESCRIPTION
This loop has potential to run infinitely if fgets() errors instead of returning something. This can happen when pms is run from X without a terminal. This results in a lot of logging to .xsession-errors.

Instead I propose to just exit if a null pointer is returned. This still allows the prompt to repeat as long as fgets() doesn't error.