### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,11 @@
 VERSION := $(shell git describe --always --long --dirty)
 
-.PHONY: all install test get-deps
+.PHONY: all install test
 
-all: get-deps test install
+all: test install
 
 install:
 	go install -ldflags="-X main.buildVersion=${VERSION}"
 
 test:
 	go test ./...
-
-get-deps:
-	go get github.com/ambientsound/gompd/mpd
-	go get github.com/blevesearch/bleve
-	go get github.com/gdamore/tcell
-	go get github.com/jessevdk/go-flags
-	go get github.com/stretchr/testify


### PR DESCRIPTION
The `go get ...` calls in the Makefile were updating go.mod, which led to build errors:
```
go get github.com/ambientsound/gompd/mpd
go: finding github.com/ambientsound/gompd latest
go get github.com/blevesearch/bleve
go: finding github.com/mschoch/smat latest
go: finding golang.org/x/sys latest
# github.com/blevesearch/bleve/index/scorch/segment/zap
../../../../pkg/mod/github.com/blevesearch/bleve@v0.8.1/index/scorch/segment/zap/posting.go:327:11: undefined: roaring.IntPeekable
../../../../pkg/mod/github.com/blevesearch/bleve@v0.8.1/index/scorch/segment/zap/posting.go:328:11: undefined: roaring.IntPeekable
gmake: *** [Makefile:15: get-deps] Error 2
```

The go.mod will get dependencies, so I if I understand it correctly, there is no need to get them "manually".

This was the diff after `make`, without my changes:
```diff
diff --git a/go.mod b/go.mod
index 6f33fd3..1ad2671 100644
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ require (
        github.com/RoaringBitmap/roaring v0.4.16 // indirect
        github.com/Smerity/govarint v0.0.0-20150407073650-7265e41f48f1 // indirect
        github.com/ambientsound/gompd v0.0.0-20170427084842-b065d40b8238
-       github.com/blevesearch/bleve v0.7.0
+       github.com/blevesearch/bleve v0.8.1
        github.com/blevesearch/go-porterstemmer v1.0.1 // indirect
        github.com/blevesearch/segment v0.0.0-20160915185041-762005e7a34f // indirect
        github.com/boltdb/bolt v1.3.1 // indirect
        github.com/couchbase/vellum v0.0.0-20180906200449-35d9e7346a69 // indirect
        github.com/davecgh/go-spew v1.1.1 // indirect
        github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712 // indirect
+       github.com/etcd-io/bbolt v1.3.3 // indirect
        github.com/gdamore/encoding v0.0.0-20151215212835-b23993cbb635 // indirect
        github.com/gdamore/tcell v1.1.0
        github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd // indirect
@@ -19,6 +20,7 @@ require (
        github.com/jessevdk/go-flags v1.4.0
        github.com/lucasb-eyer/go-colorful v0.0.0-20180709185858-c7842319cf3a // indirect
        github.com/mattn/go-runewidth v0.0.3 // indirect
+       github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae // indirect
        github.com/philhofer/fwd v1.0.0 // indirect
        github.com/pmezard/go-difflib v1.0.0 // indirect
        github.com/steveyen/gtreap v0.0.0-20150807155958-0abe01ef9be2 // indirect
@@ -26,5 +28,8 @@ require (
        github.com/tinylib/msgp v1.0.2 // indirect
        github.com/willf/bitset v1.1.9 // indirect
        golang.org/x/net v0.0.0-20180906233101-161cd47e91fd // indirect
+       golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 // indirect
        golang.org/x/text v0.3.0
 )
+
+go 1.13
```