### PR TITLE
Avoid trailing spaces in Topbar

### DIFF
--- a/widgets/topbar.go
+++ b/widgets/topbar.go
@@ -55,15 +55,15 @@ func (w *Topbar) Draw() {
 		if pieces == 0 {
 			continue
 		}
-		bufferWidth := xmax / pieces
 
 		for piece, pieceStmt := range rowStmt.Pieces {
 			// Reset X position to start of window buffer, and align left,
 			// center or right.
 			align := autoAlign(piece, pieces)
 			textWidth := pieceTextWidth(pieceStmt)
-			x := piece * bufferWidth
-			x = alignX(x, bufferWidth, textWidth, align)
+			x := getPiecesStartX(piece, pieces, xmax)
+			x2 := getPiecesStartX(piece+1, pieces, xmax)
+			x = alignX(x, x2-x, textWidth, align)
 
 			for _, fragmentStmt := range pieceStmt.Fragments {
 				frag := fragmentStmt.Instance
@@ -95,6 +95,18 @@ func autoAlign(index, total int) int {
 	default:
 		return AlignCenter
 	}
+}
+
+// getPiecesStartX calculates the start x-position for a given piece.
+//
+// Unused space is avoided by assigning extra space to the first pieces,
+// if (xmax / pieces) leaves a remainder.
+func getPiecesStartX(piece, pieces, xmax int) int {
+	x := piece * (xmax / pieces)
+	if piece <= (xmax % pieces) {
+		return x + piece
+	}
+	return x + (xmax % pieces)
 }
 
 // alignX returns the draw start position.


### PR DESCRIPTION
There were trailing spaces in the topbar, when the width of the terminal was not evenly dividable by the amount of pieces in a line of the topbar.

Example (one can see trailing whitespaces at the end of the first line):
![trailing_spaces](https://user-images.githubusercontent.com/42150522/71450964-5426c680-276c-11ea-9e4c-821c0366a681.png)

This fix was inspired by [stackoverflow.com/questions/55465884](https://stackoverflow.com/questions/55465884). It works by giving the first pieces of the line one extra character of width, until the remainder `xmax % pieces` is "used up".

This is the result: 
![fixed_topbar](https://user-images.githubusercontent.com/42150522/71450976-c7c8d380-276c-11ea-9f2d-9601d606ba4f.png)

Something like this may also be useful for the songlist, but it didn't seem like I the exact same solution would work there, at first glance. Thus I'll leave this task open for now.