### PR TITLE
Add install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ VERSION := $(shell git describe --always --long --dirty)
 DATE := $(shell date +%s)
 LDFLAGS := -ldflags="-X main.buildVersion=${VERSION}"
 
-.PHONY: pms test linux-amd64 linux-arm64 linux-arm darwin-amd64 darwin-arm64 windows-amd64.exe
+.PHONY: install pms test linux-amd64 linux-arm64 linux-arm darwin-amd64 darwin-arm64 windows-amd64.exe
+
+install: pms
+	sh ./install.sh
 
 pms:
 	go build ${LDFLAGS} -o build/pms main.go

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ make install
 ```
 
 This will put the binary in `$GOBIN/pms`, usually at `~/go/bin/pms`.
+
+If you prefer to link the binary instead of copying it, set the `INSTALL_TYPE` environment variable to `link`:
+
+```sh
+INSTALL_TYPE=link make install
+```
+
 You need to run PMS in a regular terminal with a TTY.
 
 If PMS crashes, and you want to report a bug, please include the debug log:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Infer GOBIN from GOPATH if necessary and able to
+[ "$GOBIN" == "" ] && [ "$GOPATH" != "" ]  &&
+  echo "[warning] missing \$GOBIN, using $GOPATH/bin" &&
+  GOBIN="$GOPATH/bin"
+
+# Make sure we know where to copy to
+[ "$GOBIN" == "" ] &&
+  echo '[error] $GOBIN not set' &&
+  exit 1
+
+SOURCE="$(pwd)/build/pms"
+DESTINATION="$GOBIN/pms"
+
+# Make sure we have something to copy
+[ ! -f "$SOURCE" ] &&
+  echo "[error] $SOURCE not found" &&
+  exit 1
+
+# Make room for the binary
+[ -f "$DESTINATION" ] &&
+  echo "[warning] removing existing binary $DESTINATION" &&
+  rm -f "$DESTINATION"
+
+# Check if the user wanted to link instead of copy
+[ "$INSTALL_TYPE" == "link" ] &&
+  echo "[info] linking $SOURCE to $DESTINATION" &&
+  ln -sf "$SOURCE" "$DESTINATION" &&
+  exit 0
+
+echo "[info] copying $SOURCE to $DESTINATION"
+cp "$SOURCE" "$DESTINATION"


### PR DESCRIPTION
I noticed that there was no `install` target in the Makefile, so I created one (along with an `install.sh` script).
The script now copies the `build/pms` into `$GOBIN/pms` (or creates a symbolic link if `INSTALL_TYPE=link`, might be useful for some people like myself who prefer to keep applications compiled and installed from github in `~/.local/src/github.com/`).